### PR TITLE
namespace missing

### DIFF
--- a/apps-monitoring.md
+++ b/apps-monitoring.md
@@ -171,7 +171,7 @@ And wait for the result as below:
 In order to trace networking and data transaction, we will call the Inventory service via **curl** commands via CodeReady Workspaces Terminal:
 Be sure to use your route URL of Inventory.
 
-`curl http://$(oc get route inventory-quarkus -o=go-template --template={% raw %}'{{ .spec.host }}'{% endraw %})/services/inventory/165613 ; echo`
+`curl http://$(oc get route inventory-quarkus -o=go-template --template={% raw %}'{{ .spec.host }}'{% endraw %} -n userXX-inventory)/services/inventory/165613 ; echo`
 
 Go to _Workloads > Pods_ in the left menu and click on **inventory-quarkus-xxxxxx**.
 


### PR DESCRIPTION
When the user follows the guide, they will not be in their inventory namespace and the inventory route cannot be found. To be consistent with the steps deploying inventory-quarkus, we need to also namespace the request to get the inventory-quarkus route.

As a future improvement I'd recommend using oc project instead of adding -n, except for isolated commands, because with each use of -n the user has to modify the command manually before running it.